### PR TITLE
feat: add menu for managing events and log out

### DIFF
--- a/app/src/main/java/org/fossasia/openevent/general/MainActivity.kt
+++ b/app/src/main/java/org/fossasia/openevent/general/MainActivity.kt
@@ -4,6 +4,7 @@ import android.os.Bundle
 import android.support.design.widget.BottomNavigationView
 import android.support.v4.app.Fragment
 import android.support.v7.app.AppCompatActivity
+import android.view.Menu
 import kotlinx.android.synthetic.main.activity_main.*
 import org.fossasia.openevent.general.auth.ProfileFragment
 import org.fossasia.openevent.general.event.EventsFragment
@@ -40,9 +41,20 @@ class MainActivity : AppCompatActivity() {
         loadFragment(EventsFragment())
     }
 
+    override fun onCreateOptionsMenu(menu: Menu): Boolean {
+        val inflater = menuInflater
+        inflater.inflate(R.menu.profile, menu)
+        return true
+    }
+
+    override fun onPrepareOptionsMenu(menu: Menu?): Boolean {
+        menu?.setGroupVisible(R.id.profile_menu, false)
+        return super.onPrepareOptionsMenu(menu)
+    }
+
     private fun loadFragment(fragment: Fragment) {
         supportFragmentManager.beginTransaction()
-        .replace(R.id.frame_container, fragment)
-        .commit()
+                .replace(R.id.frame_container, fragment)
+                .commit()
     }
 }

--- a/app/src/main/java/org/fossasia/openevent/general/auth/ProfileFragment.kt
+++ b/app/src/main/java/org/fossasia/openevent/general/auth/ProfileFragment.kt
@@ -88,10 +88,10 @@ class ProfileFragment : Fragment() {
     private fun startOrgaApp(packageName: String) {
         val manager = activity?.packageManager
         try {
-            val i = manager?.getLaunchIntentForPackage(packageName)
+            val intent = manager?.getLaunchIntentForPackage(packageName)
                     ?: throw  ActivityNotFoundException()
-            i.addCategory(Intent.CATEGORY_LAUNCHER)
-            startActivity(i)
+            intent.addCategory(Intent.CATEGORY_LAUNCHER)
+            startActivity(intent)
         } catch (e: ActivityNotFoundException) {
             showInMarket(packageName)
         }

--- a/app/src/main/java/org/fossasia/openevent/general/auth/ProfileFragment.kt
+++ b/app/src/main/java/org/fossasia/openevent/general/auth/ProfileFragment.kt
@@ -1,12 +1,11 @@
 package org.fossasia.openevent.general.auth
 
 import android.arch.lifecycle.Observer
+import android.content.ActivityNotFoundException
 import android.content.Intent
 import android.os.Bundle
 import android.support.v4.app.Fragment
-import android.view.LayoutInflater
-import android.view.View
-import android.view.ViewGroup
+import android.view.*
 import android.widget.Toast
 import com.squareup.picasso.Picasso
 
@@ -15,6 +14,7 @@ import org.fossasia.openevent.general.CircleTransform
 import org.fossasia.openevent.general.MainActivity
 import org.fossasia.openevent.general.R
 import org.koin.android.architecture.ext.viewModel
+import android.net.Uri
 
 
 class ProfileFragment : Fragment() {
@@ -34,13 +34,10 @@ class ProfileFragment : Fragment() {
                               savedInstanceState: Bundle?): View? {
         rootView = inflater.inflate(R.layout.fragment_profile, container, false)
 
+        setHasOptionsMenu(true)
+
         if (!profileFragmentViewModel.isLoggedIn())
             redirectToLogin()
-
-        rootView.logout.setOnClickListener {
-            profileFragmentViewModel.logout()
-            redirectToMain()
-        }
 
         profileFragmentViewModel.progress.observe(this, Observer {
             it?.let { showProgressBar(it) }
@@ -66,6 +63,44 @@ class ProfileFragment : Fragment() {
         fetchProfile()
 
         return rootView
+    }
+
+    override fun onOptionsItemSelected(item: MenuItem?): Boolean {
+        when (item?.getItemId()) {
+            R.id.orga_app -> {
+                startOrgaApp("org.fossasia.eventyay")
+                return true
+            }
+            R.id.logout -> {
+                profileFragmentViewModel.logout()
+                redirectToMain()
+                return true
+            }
+            else -> return super.onOptionsItemSelected(item)
+        }
+    }
+
+    override fun onPrepareOptionsMenu(menu: Menu?) {
+        menu?.setGroupVisible(R.id.profile_menu, true)
+        super.onPrepareOptionsMenu(menu)
+    }
+
+    private fun startOrgaApp(packageName: String) {
+        val manager = activity?.packageManager
+        try {
+            val i = manager?.getLaunchIntentForPackage(packageName)
+                    ?: throw  ActivityNotFoundException()
+            i.addCategory(Intent.CATEGORY_LAUNCHER)
+            startActivity(i)
+        } catch (e: ActivityNotFoundException) {
+            showInMarket(packageName)
+        }
+    }
+
+    private fun showInMarket(packageName: String) {
+        val intent = Intent(Intent.ACTION_VIEW, Uri.parse("market://details?id=$packageName"))
+        intent.flags = Intent.FLAG_ACTIVITY_NEW_TASK
+        startActivity(intent)
     }
 
     private fun fetchProfile() {

--- a/app/src/main/res/layout/fragment_profile.xml
+++ b/app/src/main/res/layout/fragment_profile.xml
@@ -1,6 +1,5 @@
 <FrameLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
-    xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
     android:background="@color/grey"
@@ -48,31 +47,5 @@
             android:textColor="@color/greyMore"
             android:textSize="@dimen/text_size_medium" />
 
-        <android.support.v7.widget.CardView
-            android:id="@+id/logout"
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            app:cardBackgroundColor="@color/white">
-
-            <FrameLayout
-                android:layout_width="match_parent"
-                android:layout_height="match_parent"
-                android:orientation="horizontal"
-                android:padding="@dimen/padding_large">
-
-                <TextView
-                    android:layout_width="wrap_content"
-                    android:layout_height="wrap_content"
-                    android:layout_gravity="center|start"
-                    android:text="@string/logout"
-                    android:textColor="@color/black" />
-
-                <ImageView
-                    android:layout_width="wrap_content"
-                    android:layout_height="wrap_content"
-                    android:layout_gravity="center|end"
-                    app:srcCompat="@drawable/ic_exit_to_app_black_24dp" />
-            </FrameLayout>
-        </android.support.v7.widget.CardView>
     </LinearLayout>
 </FrameLayout>

--- a/app/src/main/res/menu/profile.xml
+++ b/app/src/main/res/menu/profile.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="utf-8"?>
+<menu xmlns:android="http://schemas.android.com/apk/res/android">
+    <group android:id="@+id/profile_menu">
+        <item
+            android:id="@+id/orga_app"
+            android:title="@string/manage_events" />
+        <item
+            android:id="@+id/logout"
+            android:title="@string/logout" />
+    </group>
+</menu>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1,23 +1,19 @@
 <resources>
     <string name="app_name">open-event-general</string>
     <string name="Events">Events</string>
-    <string name="Title1">Title1</string>
-    <string name="Title2">Title2</string>
     <string name="Profile">Profile</string>
-
-    <!-- TODO: Remove or change this placeholder text -->
-    <string name="hello_blank_fragment">Hello blank fragment</string>
 
     <!--event details-->
     <string name="event_card_date">Event Date :</string>
 
     <!--profile details-->
     <string name="user_name">Username</string>
-    <string name="logout">Logout</string>
+    <string name="logout">Log out</string>
     <string name="login">Login</string>
     <string name="sign_in">No account yet? Create one</string>
     <string name="email">example@gmail.com</string>
     <string name="password">Password</string>
+    <string name="manage_events">Manage Events"</string>
 
     <!--eventyay-->
     <string name="eventyay_logo">eventyay</string>


### PR DESCRIPTION
First steps of #27 
Manage events opens the organizer's app if it is installed or else opens up the organizer's app in playstore.
Shifted log out to menu.
![screenshot_20180601-202442](https://user-images.githubusercontent.com/20878145/40847739-cd4380c6-65da-11e8-946d-c0b768f2efd3.png)
